### PR TITLE
Rename Stretch RE1 to Stretch 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Menagerie, see [CONTRIBUTING](CONTRIBUTING.md).
 | [Sawyer](rethink_robotics_sawyer/README.md)|[<img src="rethink_robotics_sawyer/sawyer.png" width="400">](rethink_robotics_sawyer/README.md)|C|
 | [xArm7](ufactory_xarm7/README.md)|[<img src="ufactory_xarm7/xarm7.png" width="400">](ufactory_xarm7/README.md)|C|
 | [Realsense D435i](realsense_d435i/README.md)|[<img src="realsense_d435i/d435i.png" width="400">](realsense_d435i/README.md)|B|
-| [Stretch RE1](hello_robot_stretch/README.md)|[<img src="hello_robot_stretch/stretch.png" width="400">](hello_robot_stretch/README.md)|C|
+| [Stretch 2](hello_robot_stretch/README.md)|[<img src="hello_robot_stretch/stretch.png" width="400">](hello_robot_stretch/README.md)|C|
 
 For corresponding embedded videos, see the MuJoCo [documentation](https://mujoco.readthedocs.io/en/latest/models.html).
 

--- a/hello_robot_stretch/README.md
+++ b/hello_robot_stretch/README.md
@@ -1,10 +1,10 @@
-# Hello Robot Stretch RE1 Description (MJCF)
+# Hello Robot Stretch 2 Description (MJCF)
 
 Requires MuJoCo 2.3.3 or later.
 
 ## Overview
 
-This package contains a simplified robot description (MJCF) of the [Hello Robot Stretch RE1](https://hello-robot.com/product) developed by [Hello Robot](https://hello-robot.com/). The original URDF and assets were provided directly by Hello Robot under the [Clear BSD License](LICENSE).
+This package contains a simplified robot description (MJCF) of the [Hello Robot Stretch 2](https://hello-robot.com/product) developed by [Hello Robot](https://hello-robot.com/). The original URDF and assets were provided directly by Hello Robot under the [Clear BSD License](LICENSE).
 
 <p float="left">
   <img src="stretch.png" width="400">


### PR DESCRIPTION
Hello!

Thank you for adding Hello Robot's Stretch to your menagerie. I noticed the model is called "Stretch RE1", but the URDF/mesh assets used to create the model are actually for "Stretch 2". This PR renamed each instance of "Stretch RE1" with "Stretch 2"

Thanks,
Binit Shah